### PR TITLE
hub,proxy,protocol: support multiple hostnames per backend (closes #9)

### DIFF
--- a/internal/hub/loadbalancer_test.go
+++ b/internal/hub/loadbalancer_test.go
@@ -11,9 +11,9 @@ func TestLoadBalancer(t *testing.T) {
 	lb := hub.NewLoadBalancerPool()
 
 	// Helper to create a Backend
-	newBackend := func(id string, weight int) *hub.Backend {
-		return hub.NewBackend(nil, id, weight, nil)
-	}
+    newBackend := func(id string, weight int) *hub.Backend {
+        return hub.NewBackend(nil, []string{id}, weight, nil)
+    }
 
 	// Test empty pool
 	if lb.HasBackends() {
@@ -54,7 +54,7 @@ func TestLoadBalancer(t *testing.T) {
 
 	// Test weighted round robin distribution
 	counts := map[string]int{}
-	for i := 0; i < 100; i++ {
+    for i := 0; i < 1000; i++ {
 		b, err := lb.Select()
 		if err != nil {
 			t.Fatalf("Unexpected error: %v", err)

--- a/internal/iface/iface.go
+++ b/internal/iface/iface.go
@@ -30,8 +30,10 @@ type Peer interface {
 
 // Backend represents a single connection from a backend service.
 type Backend interface {
-	ID() string
-	AddClient(clientConn net.Conn, clientID uuid.UUID) error
-	RemoveClient(clientID uuid.UUID)
-	SendData(clientID uuid.UUID, data []byte) error
+    ID() string
+    // AddClient associates a client connection and informs the backend about it.
+    // The hostname indicates which virtual host this client targets.
+    AddClient(clientConn net.Conn, clientID uuid.UUID, hostname string) error
+    RemoveClient(clientID uuid.UUID)
+    SendData(clientID uuid.UUID, data []byte) error
 }

--- a/internal/peer/peer-manager.go
+++ b/internal/peer/peer-manager.go
@@ -142,7 +142,7 @@ func (m *Manager) HandleTunnelRequest(p iface.Peer, hostname string, clientID uu
 	// This looks like a regular client connection to the backend.
 	// We pass a nil config because idle timeouts for tunneled connections are
 	// managed by the originating proxy.
-	client := proxy.NewClient(tunneledConn, backend, nil)
+    client := proxy.NewClient(tunneledConn, backend, nil, hostname)
 	go client.Start() // Run in a goroutine because this is initiated by the peer's read pump.
 }
 

--- a/internal/protocol/protocol.go
+++ b/internal/protocol/protocol.go
@@ -30,8 +30,10 @@ const (
 // ControlMessage defines the structure for out-of-band communication
 // between the proxy and the backend.
 type ControlMessage struct {
-	Event    EventType `json:"event"`
-	ClientID uuid.UUID `json:"client_id"`
-	ConnPort int       `json:"conn_port,omitempty"`
-	ClientIP string    `json:"client_ip,omitempty"`
+    Event    EventType `json:"event"`
+    ClientID uuid.UUID `json:"client_id"`
+    ConnPort int       `json:"conn_port,omitempty"`
+    ClientIP string    `json:"client_ip,omitempty"`
+    // Hostname is the virtual host this client connected for. Included on connect.
+    Hostname string    `json:"hostname,omitempty"`
 }

--- a/internal/proxy/http_sniff.go
+++ b/internal/proxy/http_sniff.go
@@ -46,7 +46,7 @@ func PeekHTTPHostAndPrelude(conn net.Conn, timeout time.Duration, _ int) (host s
 	if h, _, err := net.SplitHostPort(host); err == nil {
 		host = h
 	}
-	host = normalizeHostname(host)
+    host = NormalizeHostname(host)
 
 	if req.URL != nil {
 		path = req.URL.Path

--- a/internal/proxy/listener.go
+++ b/internal/proxy/listener.go
@@ -95,8 +95,8 @@ func (l *Listener) handleConnection(conn net.Conn) {
 
 	// Try TLS SNI first using a robust aborted handshake.
 	sni, tlsPrelude, tlsErr := PeekSNIAndPrelude(conn, 5*time.Second, 32<<10)
-	if tlsErr == nil && sni != "" {
-		hostname = normalizeHostname(sni)
+    if tlsErr == nil && sni != "" {
+        hostname = NormalizeHostname(sni)
 		prelude = tlsPrelude
 		isTLS = true
 	} else {
@@ -111,7 +111,7 @@ func (l *Listener) handleConnection(conn net.Conn) {
 			prelude = httpPrelude
 			isTLS = false
 			// Check if it's for our ACME HTTP-01 challenge.
-			hubHostNorm := normalizeHostname(l.config.HubPublicHostname)
+            hubHostNorm := NormalizeHostname(l.config.HubPublicHostname)
 			if l.acmeHandler != nil && hostname == hubHostNorm && localPort == 80 && strings.HasPrefix(path, "/.well-known/acme-challenge/") {
 				log.Printf("INFO: Intercepting HTTP request for proxy's own hostname '%s' on :80 to handle ACME challenge", hostname)
 				simpleHttpServer := &http.Server{Handler: l.acmeHandler, ReadHeaderTimeout: 5 * time.Second}
@@ -142,7 +142,7 @@ func (l *Listener) handleConnection(conn net.Conn) {
 	backend, err := l.hub.SelectBackend(hostname)
 	if err == nil {
 		// Forward the prelude first, then stream the rest.
-		client := NewClientWithPrelude(conn, backend, l.config, prelude)
+    client := NewClientWithPrelude(conn, backend, l.config, hostname, prelude)
 		log.Printf("INFO: [LOCAL] Routing client %s [%s] for hostname '%s' to backend %s", conn.RemoteAddr(), client.id, hostname, backend.ID())
 		client.Start()
 		return

--- a/internal/proxy/normalize.go
+++ b/internal/proxy/normalize.go
@@ -10,7 +10,7 @@ import (
 // - Drops a trailing dot
 // - Applies IDNA Lookup ToASCII mapping
 // - Lower-cases the result
-func normalizeHostname(host string) string {
+func NormalizeHostname(host string) string {
 	host = strings.TrimSpace(host)
 	if host == "" {
 		return ""


### PR DESCRIPTION
  - What changed
      - Add ControlMessage.Hostname on connect; pass through AddClient(client, id, hostname).
      - Client constructors accept hostname; listener/tunnels plumb it.
      - Hub JWT accepts hostnames[] with legacy hostname fallback; normalize/dedupe.
      - Register/unregister backends across all hostname pools.
      - Export NormalizeHostname; reuse in hub.
      - Docs updated for control message and JWT claims.
  - Why
      - Implements #9 to allow one backend WS to serve multiple FQDNs.
  - Compatibility
      - Legacy JWT with hostname still works; backends ignoring unknown JSON remain compatible.
      - Internal iface.Backend.AddClient signature updated; all call sites fixed.
  - Tests
      - Unit tests updated; go test ./... passes.
  - Follow-ups
      - #8 wildcard support (single-label, exact-match precedence) to be implemented next.